### PR TITLE
Improve technical SEO across the site

### DIFF
--- a/blog/feeds.py
+++ b/blog/feeds.py
@@ -10,7 +10,7 @@ class BlogFeed(Feed):
     description = "Lastest updates about development of Photonix"
 
     def items(self):
-        return Post.objects.order_by('-created_at')[:100]
+        return Post.objects.filter(status='published').order_by('-created_at')[:100]
 
     def item_title(self, item):
         return item.title

--- a/blog/templates/blog/post_detail.html
+++ b/blog/templates/blog/post_detail.html
@@ -10,6 +10,7 @@
 {% block og_url %}https://photonix.org/blog/{{object.slug}}/{% endblock %}
 {% block og_description %}{{ object.content|markdownify|strip_tags|truncatechars:1000 }}{% endblock %}
 {% block og_image %}{% if object.share_image %}https://photonix.org{% thumbnail object.share_image 1200x628 quality=80 crop %}{% else %}https://photonix.org/static/images/devices.jpg{% endif %}{% endblock og_image %}
+{% block og_type %}article{% endblock %}
 
 {% block extrahead %}
   <link rel="alternate" type="application/atom+xml" title="Photonix Blog Feed" href="{% url 'blog-post-feed' %}" />

--- a/faqs/templates/faqs/question_list.html
+++ b/faqs/templates/faqs/question_list.html
@@ -1,9 +1,28 @@
 {% extends "base.html" %}
-{% load thumbnail testimonials %}
+{% load thumbnail testimonials markdownify markdown_extensions %}
 
 {% block title %}Photonix Frequently Asked Questions{% endblock %}
 {% block twitter_title %}Photonix Frequently Asked Questions{% endblock %}
 {% block og_title %}Photonix Frequently Asked Questions{% endblock %}
+
+{% block extrahead %}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [{% for question_obj in question_list %}{% if not forloop.first %},{% endif %}
+      {
+        "@type": "Question",
+        "name": "{{ question_obj.title|escapejs }}",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "{{ question_obj.answer|markdownify|striptags|escapejs }}"
+        }
+      }{% endfor %}
+    ]
+  }
+  </script>
+{% endblock %}
 
 {% block content %}
   <header>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -83,7 +83,7 @@ h2 a {
   top: -14px;
   right: -4px;
   border: 1px solid black;
-  color: white;
+  color: black;
   background-color: #F54820;
   border-radius: 50%;
   width: 28px;

--- a/system/nginx.conf
+++ b/system/nginx.conf
@@ -40,7 +40,7 @@ http {
             add_header Cache-Control "public";
             gzip                on;
             gzip_proxied        any;
-            gzip_types          text/plain text/xml text/css application/x-javascript;
+            gzip_types          text/plain text/xml text/css application/javascript application/json image/svg+xml;
             gzip_vary           on;
         }
 
@@ -51,7 +51,7 @@ http {
             add_header Cache-Control "public";
             gzip                on;
             gzip_proxied        any;
-            gzip_types          text/plain text/xml text/css application/x-javascript;
+            gzip_types          text/plain text/xml text/css application/javascript application/json image/svg+xml;
             gzip_vary           on;
         }
 
@@ -62,7 +62,7 @@ http {
             add_header Cache-Control "public";
             gzip                on;
             gzip_proxied        any;
-            gzip_types          text/plain text/xml text/css application/x-javascript;
+            gzip_types          text/plain text/xml text/css application/javascript application/json image/svg+xml;
             gzip_vary           on;
         }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,6 +6,7 @@
     <title>{% block title %}Photonix Photo Manager{% endblock %}</title>
     <link rel="stylesheet" type="text/css" href="/static/css/style.css?{% version_date %}" />
     <link rel="shortcut icon" href="/static/images/favicon.png">
+    <link rel="canonical" href="{% block canonical_url %}https://photonix.org{{ request.path }}{% endblock %}" />
     <link rel="sitemap" href="/sitemap.xml" type="application/xml" />
     <link rel="manifest" href="/manifest.json" />
     <link href="https://fonts.googleapis.com/css?family=Nunito:300,600&display=swap" rel="stylesheet" />
@@ -22,7 +23,7 @@
     <meta property="og:site_name" content="Photonix Photo Manager" />
     <meta property="og:url" content="{% block og_url %}https://photonix.org/{% endblock %}" />
     <meta property="og:description" content="{% block og_description %}Photonix is a photo management application that solves a lot of problems. Once set up it will ingest all the photos in your collection and start building up an image database of everything you could want to search and filter by. It makes your entire collection available to you, whichever device you’re using — as long as you can get to a web browser.{% endblock %}" />
-    <meta property="og:type" content="product" />
+    <meta property="og:type" content="{% block og_type %}website{% endblock %}" />
     <meta property="og:image" content="{% block og_image %}https://photonix.org/static/images/devices.jpg{% endblock %}" />
     <meta property="og:locale" content="en_US" />
     <script type='text/javascript' src='/static/js/jquery.min.js'></script>
@@ -123,7 +124,7 @@
           </div>
           <div class="link">
             <a href="https://www.instagram.com/photonixapp/">
-              <img src="/static/images/instagram.svg" class="instagram" alt="Instragram logo" title="Follow updates on Instagram" />
+              <img src="/static/images/instagram.svg" class="instagram" alt="Instagram logo" title="Follow updates on Instagram" />
             </a>
           </div>
           <div class="link">
@@ -167,7 +168,7 @@
             if (repo.name == 'photonix') {
               var badge = document.getElementsByClassName('badge')[0]
               badge.innerHTML = roundStargazers(repo.stargazers_count)
-              badge.title = repo.stargazers_count
+              badge.title = repo.stargazers_count.toLocaleString() + ' GitHub stars'
               return true
             }
             return false

--- a/templates/index.html
+++ b/templates/index.html
@@ -90,8 +90,8 @@
     <p>Please note that these mobile apps will not provide any useful functionality without having a server to connect to. If you just want to play with the app or download it as a reminder, you can connect it to <a href="http://demo.photonix.org/">our demo server</a>. You can help our project succeed by leaving reviews in the app stores.</p>
 
     <div class="app-badges">
-      <a href="https://play.google.com/store/apps/details?id=org.photonix.mobile"><img src="/static/images/google-play-badge.svg" /></a>
-      <a href="https://apps.apple.com/us/app/photonix-photo-manager/id1562462420#?platform=iphone"><img src="/static/images/apple-app-store-badge.svg" /></a>
+      <a href="https://play.google.com/store/apps/details?id=org.photonix.mobile"><img src="/static/images/google-play-badge.svg" alt="Get it on Google Play" /></a>
+      <a href="https://apps.apple.com/us/app/photonix-photo-manager/id1562462420#?platform=iphone"><img src="/static/images/apple-app-store-badge.svg" alt="Download on the App Store" /></a>
     </div>
 
     <h3>Multiple users</h3>


### PR DESCRIPTION
## Summary
- Add `<link rel="canonical">` to all Django-served pages via `base.html`
- Add FAQPage structured data (JSON-LD) to the FAQ list page for rich results
- Set `og:type` to `website` by default, `article` for blog posts (was hardcoded `product`)
- Filter blog RSS feed to only include published posts (was exposing drafts)
- Update nginx gzip_types from deprecated `application/x-javascript` to modern types (`application/javascript`, `application/json`, `image/svg+xml`)
- Add missing `alt` attributes to Google Play and App Store badge images
- Fix "Instragram" typo in Instagram alt text

## Test plan
- [ ] Verify canonical tags render correctly on homepage, blog, FAQ, and static pages
- [ ] Validate FAQPage structured data with Google's Rich Results Test
- [ ] Confirm RSS feed at `/blog/feed/` only contains published posts
- [ ] Check `og:type` is `website` on homepage and `article` on blog posts
- [ ] Verify nginx gzip is working for SVG and JSON responses