### PR TITLE
Add optional S3 storage for user-uploaded media files

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -185,3 +185,31 @@ MARKDOWNIFY_WHITELIST_TAGS = [
     'h5',
 ]
 MARKDOWNIFY_BLEACH = False
+
+# S3 Storage (optional — enabled when AWS_STORAGE_BUCKET_NAME is set)
+AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME')
+if AWS_STORAGE_BUCKET_NAME:
+    INSTALLED_APPS += ['storages']
+
+    AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID')
+    AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY')
+    AWS_S3_REGION_NAME = os.environ.get('AWS_S3_REGION_NAME', 'us-east-1')
+    AWS_S3_CUSTOM_DOMAIN = os.environ.get('AWS_S3_CUSTOM_DOMAIN')
+    AWS_S3_FILE_OVERWRITE = False
+    AWS_DEFAULT_ACL = None
+    AWS_QUERYSTRING_AUTH = False
+
+    STORAGES = {
+        'default': {
+            'BACKEND': 'storages.backends.s3boto3.S3Boto3Storage',
+        },
+        'staticfiles': {
+            'BACKEND': 'django.contrib.staticfiles.storage.StaticFilesStorage',
+        },
+    }
+    THUMBNAIL_DEFAULT_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+
+    if AWS_S3_CUSTOM_DOMAIN:
+        MEDIA_URL = f'https://{AWS_S3_CUSTOM_DOMAIN}/'
+    else:
+        MEDIA_URL = f'https://{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com/'

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,5 @@ Pillow==11.2.1
 psycopg2-binary==2.9.10
 requests==2.32.3
 supervisor==4.3.0
+django-storages[s3]==1.14.4
 mkdocs==1.6.1


### PR DESCRIPTION
## Summary
- Adds `django-storages[s3]` dependency for S3-backed media storage
- Configures S3 as the default file storage for django-filer uploads and easy-thumbnails when `AWS_STORAGE_BUCKET_NAME` env var is set
- Falls back to local filesystem storage when the env var is absent, preserving the dev workflow

## Environment variables
| Variable | Required | Description |
|---|---|---|
| `AWS_STORAGE_BUCKET_NAME` | Yes (to enable) | S3 bucket name |
| `AWS_ACCESS_KEY_ID` | Yes | AWS credentials |
| `AWS_SECRET_ACCESS_KEY` | Yes | AWS credentials |
| `AWS_S3_REGION_NAME` | No (default: us-east-1) | AWS region |
| `AWS_S3_CUSTOM_DOMAIN` | No | Custom domain/CDN for media URLs |

## Test plan
- [x] Docker build succeeds
- [x] App starts and serves pages (homepage, blog, FAQs, admin)
- [ ] With AWS env vars set, verify uploads go to S3 and thumbnails are generated on S3